### PR TITLE
escape column names in default hovertool_string of stacked bar plots

### DIFF
--- a/pandas_bokeh/plot.py
+++ b/pandas_bokeh/plot.py
@@ -631,7 +631,7 @@ def plot(
                 my_hover = HoverTool(mode=hovermode, renderers=[glyph[-1]])
                 if hovertool_string is None:
                     my_hover.tooltips = [(xlabelname, "@__x__values_original")] + [
-                        (col, "@%s" % col) for col in data_cols
+                        (col, "@{%s}" % col) for col in data_cols
                     ]
                 else:
                     my_hover.tooltips = hovertool_string


### PR DESCRIPTION
Hi. Thank you for providing your great package.

I found somewhat strange behavior when plotting a stacked bar chart:
column names in  the default `hovertool_string` are not escaped and the values may not shown in the hover tooltip of the resulting html.

I think the line 634 of Pandas-Bokeh/pandas_bokeh/plot.py
```
(col, "@%s" % col) for col in data_cols
```
should be
```
(col, "@{%s}" % col) for col in data_cols
```
The default `hovertool_string`s of other types of charts are originally escaped as above.

In my environment with this change, values are shown properly in the hover tooltip of output stacked bar charts. Here is the environment I tested:
```
OS: Windos 10

# Name                    Version                   Build
anaconda                  custom           py36h363777c_0
python                    3.6.8                h9f7ef89_7
bokeh                     1.0.4                    py36_0
pandas                    0.24.1           py36ha925a31_0
```

I hope this PR helps. Thanks again for your effort.