### PR TITLE
Add constraint on bokeh and pandas version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/PatrikHlobil/Pandas-Bokeh",
     packages=setuptools.find_packages(),
-    install_requires=["bokeh", "pandas"],
+    install_requires=["bokeh >=1.2.0", "pandas >=0.24.2"],
     classifiers=[
         'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/PatrikHlobil/Pandas-Bokeh",
     packages=setuptools.find_packages(),
-    install_requires=["bokeh >=1.2.0", "pandas >=0.24.2"],
+    install_requires=["bokeh >=1.0.0", "pandas >=0.23.0"],
     classifiers=[
         'Programming Language :: Python :: 2.7',
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
pandas-bokeh has a requirement on bokeh.transform.cumsum, which was added in June 2018 to bokeh: https://github.com/bokeh/bokeh/commit/28a7f8c0fde9f058318a2ec0e5ee851d8187ec1d
I have tested with 1.2.0, but it probably also work with 1.0.0

Similarly using Pandas 0.22.0 I was getting the following error:

```
/private/home/guw/.conda/envs/fair_apex/lib/python3.6/site-packages/pandas_bokeh/__init__.py:24: Warning: Could not define plot method for Pandas DataFrame and Series. Please make sure that Pandas is installed if you wish to use Bokeh as plotting backend for Pandas.

Exceptions: cannot import name 'CachedAccessor'
```