### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include CONTRIBUTORS.md
+include tox.ini
+
+graft Tests
+graft docs


### PR DESCRIPTION
Include some other files in sdists.  In particular, include the license file, since the license requires it.  Also includes docs and unit tests.