### PR TITLE
test(rect): reproduce unemployment rect plot from bokeh docs

### DIFF
--- a/Tests/test_PandasBokeh.py
+++ b/Tests/test_PandasBokeh.py
@@ -107,6 +107,21 @@ def df_mapplot():
     return df_mapplot
 
 
+@pytest.fixture(scope="function")
+def df_unemployment():
+    from bokeh.sampledata.unemployment1948 import data
+
+    data['Year'] = data['Year'].astype(str)
+    data = data.set_index('Year')
+    data.drop('Annual', axis=1, inplace=True)
+    data.columns.name = 'Month'
+
+    # reshape to 1D array or rates with a month and year for each row.
+    df = pd.DataFrame(data.stack(), columns=['rate']).reset_index()
+
+    return df
+
+
 ##############################################################################
 ##################################TESTS#######################################
 ##############################################################################
@@ -765,3 +780,30 @@ def test_autosizing(df_fruits):
     pandas_bokeh.save(p_autoscale)
 
     assert True
+
+
+def test_rectplot(df_unemployment):
+    "Rectplot test"
+
+    kwargs = dict(
+        x="Year",
+        y="Month",
+        width=1,
+        height=1,
+        category="rate",
+        line_color=None,
+        show_figure=False,
+    )
+
+    p_rect = df_unemployment.plot_bokeh(kind="rect", **kwargs)
+    p_rect_accessor = df_unemployment.plot_bokeh.rect(**kwargs)
+
+    p_rect_pandas_backend = df_unemployment.plot(kind="rect", **kwargs)
+    p_rect_accessor_pandas_backend = df_unemployment.plot.map(**kwargs)
+
+    layout = pandas_bokeh.plot_grid(
+        [[p_rect, p_rect_accessor]], plot_width=450, plot_height=300, show_plot=False
+    )
+
+    pandas_bokeh.output_file(os.path.join(DIRECTORY, "Plots", "Rectplot.html"))
+    pandas_bokeh.save(layout)

--- a/pandas_bokeh/plot.py
+++ b/pandas_bokeh/plot.py
@@ -236,6 +236,7 @@ def plot(
         "area",
         "pie",
         "map",
+        "rect",
     ]
 
     rangetool_allowed_kinds = ["line", "step"]
@@ -843,6 +844,22 @@ def plot(
         p = pieplot(
             source,
             data_cols,
+            colormap,
+            hovertool,
+            hovertool_string,
+            figure_options,
+            xlabelname,
+            **kwargs,
+        )
+
+    if kind == "rect":
+
+        p = rectplot(
+            p,
+            source,
+            data_cols,
+            category,
+            category_values,
             colormap,
             hovertool,
             hovertool_string,


### PR DESCRIPTION
Support for rect glyphs as proposed in #84.

The idea is to reproduce [this](https://docs.bokeh.org/en/latest/docs/gallery/unemployment.html) `rect` plot from the bokeh gallery.

Right now it hits https://github.com/PatrikHlobil/Pandas-Bokeh/blob/master/pandas_bokeh/plot.py#L421 because the `Month` column is not numeric (https://github.com/PatrikHlobil/Pandas-Bokeh/blob/master/pandas_bokeh/plot.py#L418).

@PatrikHlobil what would be your general advice on how to proceed? Also, I am not yet sure how to best reuse existing code (as e.g. the `category` argument is needed to reproduce the example plot).