### PR TITLE
Fixed crash when passing string bins to histogram

### DIFF
--- a/pandas_bokeh/plot.py
+++ b/pandas_bokeh/plot.py
@@ -757,7 +757,8 @@ def plot(
             v_min, v_max = values.min(), values.max()
             bins = np.linspace(v_min, v_max, bins + 1)
 
-        bins = list(bins)
+        if not isinstance(bins, str):
+            bins = list(bins)
 
         if not weights is None:
             if weights not in df.columns:


### PR DESCRIPTION
Fix crash when passing string bins to histogram, to be consistent with the [documentation](https://github.com/PatrikHlobil/Pandas-Bokeh#histogram): *"If bins is a string, it defines the method used to calculate the optimal bin width, as defined by histogram_bin_edges."*.